### PR TITLE
Prepare installation of debug wx-config

### DIFF
--- a/ports/wxwidgets/fix-wx-config-path.patch
+++ b/ports/wxwidgets/fix-wx-config-path.patch
@@ -28,16 +28,7 @@ index 441f88c..b3a0531 100644
  # Determine the base directories we require.
 -prefix=${input_option_prefix-${this_prefix:-@prefix@}}
 +base_folder=$(dirname $(readlink -f "$0"))
-+prefix=${input_option_prefix-${this_prefix:-${base_folder}/../..}}
++prefix=${input_option_prefix-${this_prefix:-${base_folder}/@VCPKG_RELATIVE_PREFIX@}}
  exec_prefix=${input_option_exec_prefix-${input_option_prefix-${this_exec_prefix:-@exec_prefix@}}}
  wxconfdir="@libdir@/wx/config"
  
-@@ -1293,7 +1294,7 @@ else
-     _include_cppflags="-I${includedir}"
- fi
- 
--_cppflags=`echo "-I${libdir}/wx/include/@TOOLCHAIN_FULLNAME@" $_include_cppflags "@WXCONFIG_CPPFLAGS@" $_gui_cppflags`
-+_cppflags=`echo "-I${prefix}/lib/wx/include/@TOOLCHAIN_FULLNAME@" $_include_cppflags "@WXCONFIG_CPPFLAGS@" $_gui_cppflags`
- 
- # now without further ado, we can answer these too.
- [ -z "$output_option_cppflags" ] || echo $_cppflags

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -40,6 +40,10 @@ vcpkg_configure_cmake(
         -DwxUSE_STL=ON
         -DwxBUILD_DISABLE_PLATFORM_LIB_DIR=ON
         ${OPTIONS}
+    OPTIONS_RELEASE
+        -DVCPKG_RELATIVE_PREFIX=../..
+    OPTIONS_DEBUG
+        -DVCPKG_RELATIVE_PREFIX=../../../debug
 )
 
 vcpkg_install_cmake()
@@ -48,11 +52,18 @@ vcpkg_copy_pdbs()
 
 vcpkg_fixup_cmake_targets(CONFIG_PATH share/unofficial-wxwidgets TARGET_PATH share/unofficial-wxwidgets)
 
-if(VCPKG_TARGET_IS_WINDOWS)
-    vcpkg_copy_tools(TOOL_NAMES wxrc AUTO_CLEAN)
-else()
-    vcpkg_copy_tools(TOOL_NAMES wxrc wx-config wxrc-3.1 AUTO_CLEAN)
+set(tools wxrc)
+if(NOT VCPKG_TARGET_IS_WINDOWS)
+    list(APPEND tools wx-config wxrc-3.1)
 endif()
+if(NOT DEFINED VCPKG_BUILD_TYPE)
+    vcpkg_copy_tools(
+        TOOL_NAMES ${tools}
+        SEARCH_DIR "${CURRENT_PACKAGES_DIR}/debug/bin"
+        DESTINATION "${CURRENT_PACKAGES_DIR}/tools/${PORT}/debug"
+    )
+endif()
+vcpkg_copy_tools(TOOL_NAMES ${tools} AUTO_CLEAN)
 
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/include/msvc")
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")


### PR DESCRIPTION
This adds the installation of a debug variant of `wx-config`. It needs to be complemented by a change to the vcpkg cmake wrapper for cmake's FindwxWidgets module.